### PR TITLE
Feature/game page details

### DIFF
--- a/src/components/Chip.jsx
+++ b/src/components/Chip.jsx
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled'
+import { Chip as MuiChip } from '@mui/material'
+
+import { color } from '../styles'
+
+export const Chip = ({ ...props }) => <StyledChip variant="outlined" {...props} />
+
+const StyledChip = styled(MuiChip)`
+  &.MuiChip-root {
+    border-color: ${color.primaryColor400};
+  }
+`

--- a/src/components/Dialog.jsx
+++ b/src/components/Dialog.jsx
@@ -44,6 +44,7 @@ Dialog.defaultProps = {
 const StyledDialog = styled(MuiDialog)`
   & .MuiDialog-paper {
     min-width: 20rem;
+    max-width: 50rem;
   }
 `
 const StyledDialogTitle = styled(DialogTitle)`

--- a/src/components/Dialog.jsx
+++ b/src/components/Dialog.jsx
@@ -9,18 +9,22 @@ export const DialogTypes = {
   SIMPLE: 'SIMPLE',
 }
 
-export const Dialog = ({ title, type, children, onConfirm, onCancel, ...dialogProps }) => (
+export const Dialog = ({ title, type, children, onConfirm, onCancel, disabled, ...dialogProps }) => (
   <StyledDialog {...dialogProps}>
     <StyledDialogTitle>{title}</StyledDialogTitle>
     <DialogContent>{children}</DialogContent>
     {type === DialogTypes.CONFIRM && (
       <DialogActions>
-        <Button width="5rem" onClick={onCancel}>
-          取消
-        </Button>
-        <Button width="5rem" onClick={onConfirm}>
-          確認
-        </Button>
+        {onCancel && (
+          <Button width="5rem" disabled={disabled} onClick={onCancel}>
+            取消
+          </Button>
+        )}
+        {onConfirm && (
+          <Button width="5rem" disabled={disabled} onClick={onConfirm}>
+            確認
+          </Button>
+        )}
       </DialogActions>
     )}
   </StyledDialog>
@@ -30,15 +34,17 @@ Dialog.propTypes = {
   title: PropTypes.string,
   type: PropTypes.oneOf(Object.keys(DialogTypes)),
   children: PropTypes.any,
-  onConfirm: PropTypes.func,
-  onCancel: PropTypes.func,
+  onConfirm: PropTypes.oneOf([PropTypes.func, null]),
+  onCancel: PropTypes.oneOf([PropTypes.func, null]),
+  disabled: PropTypes.bool,
 }
 Dialog.defaultProps = {
   title: '',
   type: DialogTypes.SIMPLE,
   children: null,
-  onConfirm: () => {},
-  onCancel: () => {},
+  onConfirm: null,
+  onCancel: null,
+  disabled: false,
 }
 
 const StyledDialog = styled(MuiDialog)`

--- a/src/components/HoverTooltip.jsx
+++ b/src/components/HoverTooltip.jsx
@@ -1,0 +1,39 @@
+import PropTypes from 'prop-types'
+import styled from '@emotion/styled'
+import { Tooltip as MuiTooltip, Popper } from '@mui/material'
+import { InfoOutlined } from '@mui/icons-material'
+
+import { color } from '../styles'
+
+const StyledIcon = styled(InfoOutlined)`
+  &.MuiSvgIcon-root {
+    color: ${color.neutralsColor700};
+    width: 1rem;
+    height: 1rem;
+  }
+`
+const StyledPopper = styled(Popper)`
+  &.MuiTooltip-popper {
+    z-index: 999999 !important;
+  }
+  .MuiTooltip-tooltip {
+    &.MuiTooltip-tooltipPlacementRight {
+      margin-left: 0.25rem;
+    }
+  }
+`
+
+export const HoverTooltip = ({ tooltip }) => (
+  <MuiTooltip title={tooltip} placement="right" components={{ Popper: StyledPopper }}>
+    <div>
+      <StyledIcon />
+    </div>
+  </MuiTooltip>
+)
+
+HoverTooltip.propTypes = {
+  tooltip: PropTypes.string,
+}
+HoverTooltip.defaultProps = {
+  tooltip: '',
+}

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -1,4 +1,5 @@
 import { Button } from './Button'
 import { Dialog, DialogTypes } from './Dialog'
+import { Chip } from './Chip'
 
-export { Button, Dialog, DialogTypes }
+export { Button, Dialog, DialogTypes, Chip }

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -1,5 +1,6 @@
 import { Button } from './Button'
 import { Dialog, DialogTypes } from './Dialog'
 import { Chip } from './Chip'
+import { HoverTooltip } from './HoverTooltip'
 
-export { Button, Dialog, DialogTypes, Chip }
+export { Button, Dialog, DialogTypes, Chip, HoverTooltip }

--- a/src/models/Tools.js
+++ b/src/models/Tools.js
@@ -7,3 +7,36 @@ export const Tools = {
   HPRA: '重要程度',
   FINDER: 'AI_FINDER',
 }
+
+export const toolsAvailable = {
+  NO_HELP: {
+    code: 0,
+    displayName: '自行判斷',
+    introduction: '代表...',
+  },
+  HDA: {
+    code: 1,
+    displayName: '連結程度',
+    introduction: '代表...',
+  },
+  HCA: {
+    code: 2,
+    displayName: '距離長短',
+    introduction: '代表...',
+  },
+  HBA: {
+    code: 3,
+    displayName: '中介程度',
+    introduction: '代表...',
+  },
+  HPRA: {
+    code: 4,
+    displayName: '重要程度',
+    introduction: '代表...',
+  },
+  FINDER: {
+    code: 5,
+    displayName: 'AI_FINDER',
+    introduction: '代表...',
+  },
+}

--- a/src/pages/game/ForceGraph.jsx
+++ b/src/pages/game/ForceGraph.jsx
@@ -42,7 +42,7 @@ export const ForceGraph = ({ graphData = { nodes: [], links: [] }, onRemoveNode 
         return getNodeColorByRanking({ ranking: graphRanking[node.id] })
       }}
       onNodeClick={handleClickNode}
-      width={width - 8 * 14}
+      width={width - 8 * 14 - 470}
       height={height - 8 * 14}
     />
   )

--- a/src/pages/game/Game.jsx
+++ b/src/pages/game/Game.jsx
@@ -67,6 +67,7 @@ export const GamePage = () => {
     setIsInformationBlockShown(false)
     setTimeout(() => {
       setIsToolSelectionDialogOpen(true)
+      dispatch(updateGraphRanking(null))
     }, 1000)
   }
 

--- a/src/pages/game/Game.jsx
+++ b/src/pages/game/Game.jsx
@@ -6,8 +6,9 @@ import styled from '@emotion/styled'
 
 import { API_ROOT } from '../../api.config'
 import { Button } from '../../components'
-import { selectNetworkCode, updateGraphRanking, updatePayoff, resetGameData } from './game.slice'
+import { selectNetworkCode, updateGraphRanking, updateSelectedTool, updatePayoff, resetGameData } from './game.slice'
 import { ToolSelectionDialog } from './ToolSelectionDialog'
+import { InformationBlock } from './InformationBlock'
 import { QuitGameDialog } from './QuitGameDialog'
 import { ForceGraph } from './ForceGraph'
 
@@ -17,6 +18,7 @@ export const GamePage = () => {
   const networkCode = useSelector(selectNetworkCode)
 
   const [isToolSelectionDialogOpen, setIsToolSelectionDialogOpen] = useState(false)
+  const [isInformationBlockShown, setIsInformationBlockShown] = useState(false)
   const [isQuitGameDialogOpen, setIsQuitGameDialogOpen] = useState(false)
 
   useEffect(() => {
@@ -41,8 +43,9 @@ export const GamePage = () => {
     },
   })
 
-  const onSelectTool = () => {
+  const onSelectTool = tool => {
     setIsToolSelectionDialogOpen(false)
+    setIsInformationBlockShown(true)
     dispatch(
       updateGraphRanking(
         graphData
@@ -53,6 +56,7 @@ export const GamePage = () => {
           : {},
       ),
     ) // TODO: call node_ranking api to get rank -> put in redux
+    dispatch(updateSelectedTool(tool))
   }
 
   const onRemoveNode = () => {
@@ -60,6 +64,7 @@ export const GamePage = () => {
     dispatch(
       updatePayoff({ payoffHuman: Math.random(), payoffFinder: Array.from({ length: 10 }, () => Math.random()) }),
     )
+    setIsInformationBlockShown(false)
     setTimeout(() => {
       setIsToolSelectionDialogOpen(true)
     }, 1000)
@@ -80,9 +85,10 @@ export const GamePage = () => {
         onCancel={() => setIsQuitGameDialogOpen(false)}
       />
 
-      <StyledForceGraphContainer>
+      <StyledGameContainer>
+        <InformationBlock visible={isInformationBlockShown || isQuitGameDialogOpen} />
         <ForceGraph graphData={graphData} onRemoveNode={onRemoveNode} />
-      </StyledForceGraphContainer>
+      </StyledGameContainer>
     </StyledGamePageContainer>
   )
 }
@@ -91,8 +97,10 @@ const StyledGamePageContainer = styled.div`
   padding: 2rem 4rem;
   position: relative;
 `
-const StyledForceGraphContainer = styled.div`
+const StyledGameContainer = styled.div`
   padding-top: 3rem;
+  display: flex;
+  align-items: flex-start;
 `
 const StyledQuitGameButton = styled(Button)`
   position: absolute;

--- a/src/pages/game/InformationBlock.jsx
+++ b/src/pages/game/InformationBlock.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import styled from '@emotion/styled'
 import { Card } from '@mui/material'
 
-import { Chip } from '../../components'
+import { Chip, HoverTooltip } from '../../components'
 import { selectSelectedTool, selectPayoff } from './game.slice'
 import { PayoffChart } from './PayoffChart'
 
@@ -20,7 +20,8 @@ export const InformationBlock = ({ visible }) => {
       </StyledRow>
       <StyledRow>
         <Chip label="本回合輔助指標" />
-        <div>{selectedTool[selectedTool.length - 1]}</div>
+        <div>{selectedTool[selectedTool.length - 1]?.displayName ?? ''}</div>
+        <HoverTooltip tooltip={selectedTool[selectedTool.length - 1]?.introduction} />
       </StyledRow>
       {round > 1 && (
         <>

--- a/src/pages/game/InformationBlock.jsx
+++ b/src/pages/game/InformationBlock.jsx
@@ -1,0 +1,58 @@
+import { useSelector } from 'react-redux'
+import PropTypes from 'prop-types'
+import styled from '@emotion/styled'
+import { Card } from '@mui/material'
+
+import { Chip } from '../../components'
+import { selectSelectedTool, selectPayoff } from './game.slice'
+import { PayoffChart } from './PayoffChart'
+
+export const InformationBlock = ({ visible }) => {
+  const selectedTool = useSelector(selectSelectedTool)
+  const payoff = useSelector(selectPayoff)
+  const round = (payoff?.payoffHuman ?? []).length + 1
+
+  return (
+    <StyledCard visible={visible}>
+      <StyledRow>
+        <Chip label="回合" />
+        <div>{round}</div>
+      </StyledRow>
+      <StyledRow>
+        <Chip label="本回合輔助指標" />
+        <div>{selectedTool[selectedTool.length - 1]}</div>
+      </StyledRow>
+      {round > 1 && (
+        <>
+          <StyledRow>
+            <Chip label="累積報酬" />
+          </StyledRow>
+          <PayoffChart />
+        </>
+      )}
+    </StyledCard>
+  )
+}
+
+InformationBlock.propTypes = {
+  visible: PropTypes.bool,
+}
+InformationBlock.defaultProps = {
+  visible: false,
+}
+
+const StyledCard = styled(Card)`
+  &.MuiPaper-root {
+    visibility: ${props => (props.visible ? 'visible' : 'hidden')};
+    width: calc(400px + 4rem);
+    padding: 1.5rem 3rem 1.5rem 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+`
+const StyledRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+`

--- a/src/pages/game/PayoffChart.jsx
+++ b/src/pages/game/PayoffChart.jsx
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux'
 import { LineChart, Line, CartesianGrid, XAxis, YAxis, Legend } from 'recharts'
 
+import { color } from '../../styles'
 import { selectPayoff } from './game.slice'
 import { parsePayoffDataForChart } from './game.utils'
 
@@ -9,12 +10,12 @@ export const PayoffChart = () => {
   const data = parsePayoffDataForChart({ payoffRawData })
 
   return (
-    <LineChart width={400} height={300} data={data}>
-      <Line name="Human Payoff" type="monotone" dataKey="payoffHuman" stroke="#8884d8" />
-      <Line name="FINDER Payoff" type="monotone" dataKey="payoffFinder" stroke="#82ca9d" />
-      <CartesianGrid stroke="#ccc" />
-      <XAxis dataKey="name" label={{ value: '回合', position: 'insideBottom', offset: 0 }} scale="band" />
-      <YAxis label={{ value: '報酬', angle: -90, position: 'insideLeft' }} />
+    <LineChart width={400} height={300} data={data} overflow="visible">
+      <Line name="您的成績" type="monotone" dataKey="payoffHuman" stroke={color.primaryColor600} />
+      <Line name="AI FINDER 的成績" type="monotone" dataKey="payoffFinder" stroke={color.neutralsColor600} />
+      <CartesianGrid stroke={color.neutralsColor400} />
+      <XAxis dataKey="name" label={{ value: '回合', position: 'insideBottom', offset: -15 }} scale="band" />
+      <YAxis label={{ value: '報酬', angle: -90, position: 'insideLeft', offset: 5 }} />
       <Legend verticalAlign="top" height={36} />
     </LineChart>
   )

--- a/src/pages/game/ToolSelectionDialog.jsx
+++ b/src/pages/game/ToolSelectionDialog.jsx
@@ -15,7 +15,7 @@ export const ToolSelectionDialog = ({ open = false, onConfirm = () => {} }) => {
       <StyledDialogContent>
         <StyledOptionsContainer>
           {Object.values(Tools).map(tool => (
-            <Button key={tool} onClick={onConfirm}>
+            <Button key={tool} onClick={() => onConfirm(tool)}>
               {tool}
             </Button>
           ))}

--- a/src/pages/game/ToolSelectionDialog.jsx
+++ b/src/pages/game/ToolSelectionDialog.jsx
@@ -19,6 +19,7 @@ export const ToolSelectionDialog = ({ open = false, onConfirm = () => {} }) => {
       open={open}
       title="選擇下一回合輔助指標"
       type={DialogTypes.CONFIRM}
+      disabled={!expandedTool}
       onConfirm={() => {
         onConfirm(expandedTool)
         setExpandedTool(null)
@@ -69,7 +70,7 @@ const StyledOptionsContainer = styled.div`
 const StyledOptionContainer = styled.div`
   display: flex;
   flex-direction: column;
-  width: 10rem;
+  width: 17rem;
 `
 const StyledAccordion = styled(Accordion)`
   background-color: ${props => props.expanded && color.primaryColor400};
@@ -79,6 +80,7 @@ const StyledAccordionDetails = styled(AccordionDetails)`
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
+  font-size: 0.75rem;
 `
 const StyledChartContainer = styled.div`
   display: flex;

--- a/src/pages/game/ToolSelectionDialog.jsx
+++ b/src/pages/game/ToolSelectionDialog.jsx
@@ -1,26 +1,44 @@
+import { useState } from 'react'
 import { useSelector } from 'react-redux'
 import PropTypes from 'prop-types'
 import styled from '@emotion/styled'
+import { Accordion, AccordionSummary, AccordionDetails } from '@mui/material'
 
-import { Tools } from '../../models/Tools'
-import { Button, Dialog, Chip } from '../../components'
-import { selectGraphRanking } from './game.slice'
+import { color } from '../../styles'
+import { Dialog, DialogTypes, Chip } from '../../components'
+import { selectToolsAvailable, selectPayoff } from './game.slice'
 import { PayoffChart } from './PayoffChart'
 
 export const ToolSelectionDialog = ({ open = false, onConfirm = () => {} }) => {
-  const graphRanking = useSelector(selectGraphRanking)
+  const toolsAvailable = useSelector(selectToolsAvailable)
+  const payoff = useSelector(selectPayoff)
+  const [expandedTool, setExpandedTool] = useState(null)
 
   return (
-    <Dialog open={open} title="選擇輔助指標">
+    <Dialog
+      open={open}
+      title="選擇下一回合輔助指標"
+      type={DialogTypes.CONFIRM}
+      onConfirm={() => {
+        onConfirm(expandedTool)
+        setExpandedTool(null)
+      }}
+    >
       <StyledDialogContent>
         <StyledOptionsContainer>
-          {Object.values(Tools).map(tool => (
-            <Button key={tool} onClick={() => onConfirm(tool)}>
-              {tool}
-            </Button>
+          {Object.values(toolsAvailable).map(tool => (
+            <StyledOptionContainer key={tool.code}>
+              <StyledAccordion
+                expanded={(expandedTool?.code ?? '') === tool.code}
+                onChange={() => setExpandedTool(tool)}
+              >
+                <AccordionSummary>{tool.displayName}</AccordionSummary>
+                <StyledAccordionDetails>{tool.introduction}</StyledAccordionDetails>
+              </StyledAccordion>
+            </StyledOptionContainer>
           ))}
         </StyledOptionsContainer>
-        {!!graphRanking && (
+        {!!payoff && (
           <StyledChartContainer>
             <Chip label="累積報酬" />
             <PayoffChart />
@@ -47,6 +65,20 @@ const StyledOptionsContainer = styled.div`
   align-items: center;
   gap: 0.5rem;
   width: 100%;
+`
+const StyledOptionContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 10rem;
+`
+const StyledAccordion = styled(Accordion)`
+  background-color: ${props => props.expanded && color.primaryColor400};
+  color: ${props => props.expanded && color.neutralsColor0};
+`
+const StyledAccordionDetails = styled(AccordionDetails)`
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 `
 const StyledChartContainer = styled.div`
   display: flex;

--- a/src/pages/game/ToolSelectionDialog.jsx
+++ b/src/pages/game/ToolSelectionDialog.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types'
 import styled from '@emotion/styled'
 
 import { Tools } from '../../models/Tools'
+import { Button, Dialog, Chip } from '../../components'
 import { selectGraphRanking } from './game.slice'
-import { Button, Dialog } from '../../components'
 import { PayoffChart } from './PayoffChart'
 
 export const ToolSelectionDialog = ({ open = false, onConfirm = () => {} }) => {
@@ -22,7 +22,7 @@ export const ToolSelectionDialog = ({ open = false, onConfirm = () => {} }) => {
         </StyledOptionsContainer>
         {!!graphRanking && (
           <StyledChartContainer>
-            <StyledChartTitle>累積報酬</StyledChartTitle>
+            <Chip label="累積報酬" />
             <PayoffChart />
           </StyledChartContainer>
         )}
@@ -53,7 +53,6 @@ const StyledChartContainer = styled.div`
   flex-direction: column;
   align-items: flex-start;
   gap: 1rem;
-`
-const StyledChartTitle = styled.span`
-  padding-left: 2rem;
+  padding: 1rem;
+  padding-top: 0;
 `

--- a/src/pages/game/game.slice.js
+++ b/src/pages/game/game.slice.js
@@ -7,6 +7,7 @@ const initialState = {
   networkCode: null,
   graphData: null,
   graphRanking: null,
+  selectedTool: [],
   payoff: null,
 }
 
@@ -30,6 +31,10 @@ const gameSlice = createSlice({
       state.graphRanking = action.payload
     },
 
+    updateSelectedTool: (state, action) => {
+      state.selectedTool = [...state.selectedTool, action.payload]
+    },
+
     updatePayoff: (state, action) => {
       state.payoff = {
         payoffHuman: [...(state?.payoff?.payoffHuman ?? []), action.payload.payoffHuman],
@@ -47,12 +52,20 @@ const gameSlice = createSlice({
   },
 })
 
-export const { updateGameStage, updateNetworkCode, updateGraphData, updateGraphRanking, updatePayoff, resetGameData } =
-  gameSlice.actions
+export const {
+  updateGameStage,
+  updateNetworkCode,
+  updateGraphData,
+  updateGraphRanking,
+  updateSelectedTool,
+  updatePayoff,
+  resetGameData,
+} = gameSlice.actions
 export default gameSlice.reducer
 
 export const selectGameStage = state => state.gameReducer.gameStage
 export const selectNetworkCode = state => state.gameReducer.networkCode
 export const selectGraphData = state => state.gameReducer.graphData
 export const selectGraphRanking = state => state.gameReducer.graphRanking
+export const selectSelectedTool = state => state.gameReducer.selectedTool
 export const selectPayoff = state => state.gameReducer.payoff

--- a/src/pages/game/game.slice.js
+++ b/src/pages/game/game.slice.js
@@ -3,6 +3,9 @@ import { createSlice } from '@reduxjs/toolkit'
 import { GameStages } from '../../models/GameStages'
 
 const initialState = {
+  networksAvailable: {},
+  toolsAvailable: {},
+
   gameStage: GameStages.NETWORK_SELECTION,
   networkCode: null,
   graphData: null,
@@ -15,6 +18,14 @@ const gameSlice = createSlice({
   name: 'gameSlice',
   initialState,
   reducers: {
+    updateNetworksAvailable: (state, action) => {
+      state.networksAvailable = action.payload
+    },
+
+    updateToolsAvailable: (state, action) => {
+      state.toolsAvailable = action.payload
+    },
+
     updateGameStage: (state, action) => {
       state.gameStage = action.payload
     },
@@ -53,6 +64,9 @@ const gameSlice = createSlice({
 })
 
 export const {
+  updateNetworksAvailable,
+  updateToolsAvailable,
+
   updateGameStage,
   updateNetworkCode,
   updateGraphData,
@@ -62,6 +76,9 @@ export const {
   resetGameData,
 } = gameSlice.actions
 export default gameSlice.reducer
+
+export const selectNetworksAvailable = state => state.gameReducer.networksAvailable
+export const selectToolsAvailable = state => state.gameReducer.toolsAvailable
 
 export const selectGameStage = state => state.gameReducer.gameStage
 export const selectNetworkCode = state => state.gameReducer.networkCode

--- a/src/styles/color.js
+++ b/src/styles/color.js
@@ -15,6 +15,10 @@ const neutralsColor = {
   neutralsColor100: '#f9fbff',
   neutralsColor400: '#e2e4e8',
   neutralsColor500: '#C0C1C5',
+  neutralsColor600: '#A1A3A7',
+  neutralsColor700: '#787A7D',
+  neutralsColor800: '#646569',
+  neutralsColor900: '#444649',
   neutralsColor1000: '#232528',
 }
 


### PR DESCRIPTION
# Issue Link

https://github.com/johnny890122/FINDER_react_frontend/issues/17

## Feature

- 輔助指標需要能顯示相關文字說明，因為玩家可以直接選擇 start 進入遊戲，而不經過 TOUR。
- 圖標：您的成績（用明顯一點的顏色）、AI FINDER 的成績（用灰色之類的）
- 指標文字改成：{"NO_HELP": "自行判斷", "HDA": "連結程度", "HCA": "距離長短", "HBA": "中介程度", "HPRA": "重要程度", "FINDER": "AI_FINDER"}
- 顯示回合數
- 顯示該回合用的指標
- 彈出指標畫面時，背景的 graph 可能要以 no_help 的方式上色
- Dialog 的確認和取消按鈕狀態