### PR TITLE
fix: payoff chart

### DIFF
--- a/src/pages/game/Game.jsx
+++ b/src/pages/game/Game.jsx
@@ -124,7 +124,13 @@ export const GamePage = () => {
       return response.json()
     },
     onSuccess: payoffResponse => {
-      dispatch(updatePayoff({ payoffHuman: payoffResponse?.human_payoff, payoffFinder: payoffResponse?.finder_payoff, payoffInstantFinder: payoffResponse?.instant_finder_payoff}))
+      dispatch(
+        updatePayoff({
+          payoffHuman: payoffResponse?.human_payoff,
+          payoffFinder: payoffResponse?.finder_payoff,
+          payoffInstantFinder: payoffResponse?.instant_finder_payoff,
+        }),
+      )
       if (payoffResponse?.isEnd) {
         setIsGameEndDialogOpen(true)
       } else {

--- a/src/pages/game/Game.jsx
+++ b/src/pages/game/Game.jsx
@@ -124,7 +124,7 @@ export const GamePage = () => {
       return response.json()
     },
     onSuccess: payoffResponse => {
-      dispatch(updatePayoff({ payoffHuman: payoffResponse?.human_payoff, payoffFinder: payoffResponse?.finder_payoff }))
+      dispatch(updatePayoff({ payoffHuman: payoffResponse?.human_payoff, payoffFinder: payoffResponse?.finder_payoff, payoffInstantFinder: payoffResponse?.instant_finder_payoff}))
       if (payoffResponse?.isEnd) {
         setIsGameEndDialogOpen(true)
       } else {

--- a/src/pages/game/PayoffChart.jsx
+++ b/src/pages/game/PayoffChart.jsx
@@ -12,8 +12,9 @@ export const PayoffChart = ({ width, height }) => {
 
   return (
     <LineChart width={width} height={height} data={data} overflow="visible">
-      <Line name="您的成績" type="monotone" dataKey="payoffHuman" stroke={color.primaryColor600} />
       <Line name="AI FINDER 的成績" type="monotone" dataKey="payoffFinder" stroke={color.neutralsColor600} />
+      <Line name="一直遵守 AI FINDER 的成績" type="monotone" dataKey="payoffInstantFinder" stroke={color.neutralsColor800} />
+      <Line name="您的成績" type="monotone" dataKey="payoffHuman" stroke={color.primaryColor600} />
       <CartesianGrid stroke={color.neutralsColor400} />
       <XAxis dataKey="name" label={{ value: '回合', position: 'insideBottom', offset: -15 }} interval={0} />
       <YAxis
@@ -22,7 +23,7 @@ export const PayoffChart = ({ width, height }) => {
         label={{ value: '報酬', angle: -90, position: 'insideLeft', offset: 5 }}
         tickFormatter={value => value.toFixed(2)}
       />
-      <Legend verticalAlign="top" height={36} />
+      <Legend verticalAlign="top" height={45} />
     </LineChart>
   )
 }

--- a/src/pages/game/PayoffChart.jsx
+++ b/src/pages/game/PayoffChart.jsx
@@ -13,7 +13,12 @@ export const PayoffChart = ({ width, height }) => {
   return (
     <LineChart width={width} height={height} data={data} overflow="visible">
       <Line name="AI FINDER 的成績" type="monotone" dataKey="payoffFinder" stroke={color.neutralsColor600} />
-      <Line name="一直遵守 AI FINDER 的成績" type="monotone" dataKey="payoffInstantFinder" stroke={color.neutralsColor800} />
+      <Line
+        name="一直遵守 AI FINDER 的成績"
+        type="monotone"
+        dataKey="payoffInstantFinder"
+        stroke={color.neutralsColor800}
+      />
       <Line name="您的成績" type="monotone" dataKey="payoffHuman" stroke={color.primaryColor600} />
       <CartesianGrid stroke={color.neutralsColor400} />
       <XAxis dataKey="name" label={{ value: '回合', position: 'insideBottom', offset: -15 }} interval={0} />

--- a/src/pages/game/game.slice.js
+++ b/src/pages/game/game.slice.js
@@ -50,6 +50,7 @@ const gameSlice = createSlice({
       state.payoff = {
         payoffHuman: [...(state?.payoff?.payoffHuman ?? []), action.payload.payoffHuman],
         payoffFinder: action.payload.payoffFinder,
+        payoffInstantFinder: action.payload.payoffInstantFinder,
       }
     },
 

--- a/src/pages/game/game.utils.js
+++ b/src/pages/game/game.utils.js
@@ -10,26 +10,22 @@ export const calculateCumulativeSum = ({ data }) => {
   return cumulativeData
 }
 
-export const concatPayoffFinderWithCumulativePayoffHuman = ({ cumulativePayoffHuman, payoffFinder }) => {
-  const cumulativePayoffHumanWithoutLastElement = cumulativePayoffHuman.slice(0, -1)
+export const concatPayoffFinderWithCumulativePayoffHuman = ({ payoffHuman, payoffFinder }) => {
+  const cumulativePayoffHumanWithoutLastElement = payoffHuman.slice(0, -1)
   return [...cumulativePayoffHumanWithoutLastElement, ...payoffFinder]
 }
 
 export const parsePayoffDataForChart = ({ payoffRawData }) => {
   if (!payoffRawData) return []
-  const { payoffHuman, payoffFinder } = payoffRawData
-  const cumulativePayoffHuman = calculateCumulativeSum({ data: payoffHuman })
-  const payoffFinderWithFutureRounds = concatPayoffFinderWithCumulativePayoffHuman({
-    cumulativePayoffHuman,
-    payoffFinder,
-  })
+  const { payoffHuman, payoffFinder, payoffInstantFinder} = payoffRawData
 
   const payoff = []
-  for (let i = 0; i < payoffFinderWithFutureRounds.length; i += 1) {
+  for (let i = 0; i < payoffFinder.length; i += 1) {
     payoff.push({
       name: i + 1,
-      payoffHuman: cumulativePayoffHuman[i] ?? null,
-      payoffFinder: payoffFinderWithFutureRounds[i],
+      payoffHuman: payoffHuman[i] ?? null,
+      payoffFinder: payoffFinder[i],
+      payoffInstantFinder: payoffInstantFinder[i],
     })
   }
 

--- a/src/pages/game/game.utils.js
+++ b/src/pages/game/game.utils.js
@@ -10,14 +10,9 @@ export const calculateCumulativeSum = ({ data }) => {
   return cumulativeData
 }
 
-export const concatPayoffFinderWithCumulativePayoffHuman = ({ payoffHuman, payoffFinder }) => {
-  const cumulativePayoffHumanWithoutLastElement = payoffHuman.slice(0, -1)
-  return [...cumulativePayoffHumanWithoutLastElement, ...payoffFinder]
-}
-
 export const parsePayoffDataForChart = ({ payoffRawData }) => {
   if (!payoffRawData) return []
-  const { payoffHuman, payoffFinder, payoffInstantFinder} = payoffRawData
+  const { payoffHuman, payoffFinder, payoffInstantFinder } = payoffRawData
 
   const payoff = []
   for (let i = 0; i < payoffFinder.length; i += 1) {

--- a/src/pages/game/game.utils.spec.js
+++ b/src/pages/game/game.utils.spec.js
@@ -1,7 +1,5 @@
 import {
   getNodeValue,
-  calculateCumulativeSum,
-  concatPayoffFinderWithCumulativePayoffHuman,
   parsePayoffDataForChart,
   getNeighborNodeIds,
   getNeighborLinks,
@@ -16,39 +14,20 @@ describe('getNodeValue', () => {
   })
 })
 
-describe('calculateCumulativeSum', () => {
-  it('given empty array, return empty array', () => {
-    expect(calculateCumulativeSum({ data: [] })).toEqual([])
-  })
-  it('given non-empty array, calculate cumulative sum', () => {
-    const data = [1, 2, 3]
-    const expectedResult = [1, 3, 6]
-    expect(calculateCumulativeSum({ data })).toEqual(expectedResult)
-  })
-})
-
-describe('concatPayoffFinderWithCumulativePayoffHuman', () => {
-  it('should concat payoff finder with cumulative payoff human', () => {
-    const cumulativePayoffHuman = [1, 3, 5]
-    const payoffFinder = [6, 7, 8]
-    expect(concatPayoffFinderWithCumulativePayoffHuman({ cumulativePayoffHuman, payoffFinder })).toEqual([
-      1, 3, 6, 7, 8,
-    ])
-  })
-})
-
 describe('parsePayoffDataForChart', () => {
   it('should return empty array if there is no input', () => {
     expect(parsePayoffDataForChart({ payoffRawData: null })).toEqual([])
   })
-  it('should combine payoffHuman and payoffFinder in return value', () => {
-    const payoffRawData = { payoffHuman: [1, 2, 3], payoffFinder: [7, 8, 9] }
+  it('should return data with payoffHuman, payoffFinder, and payoffInstantFinder', () => {
+    const payoffRawData = {
+      payoffHuman: [1, 2, 3],
+      payoffFinder: [7, 8, 9],
+      payoffInstantFinder: [4, 5, 6],
+    }
     const expectPayoff = [
-      { name: 1, payoffHuman: 1, payoffFinder: 1 },
-      { name: 2, payoffHuman: 3, payoffFinder: 3 },
-      { name: 3, payoffHuman: 6, payoffFinder: 7 },
-      { name: 4, payoffHuman: null, payoffFinder: 8 },
-      { name: 5, payoffHuman: null, payoffFinder: 9 },
+      { name: 1, payoffHuman: 1, payoffFinder: 7, payoffInstantFinder: 4 },
+      { name: 2, payoffHuman: 2, payoffFinder: 8, payoffInstantFinder: 5 },
+      { name: 3, payoffHuman: 3, payoffFinder: 9, payoffInstantFinder: 6 },
     ]
 
     expect(parsePayoffDataForChart({ payoffRawData })).toEqual(expectPayoff)


### PR DESCRIPTION
feat: 新增從一開始就按照 FINDER 選擇的 payoff
目前有三條
1. 人類的 payoff
2. 一直使用 AI FINDER 的成績（不會隨著回合數改變, aka finder_payoff）
3. 從該回合開始使用 AI FINDER 的成績（i.e. 人類的payoff + 該回合開始的 finder payoff）

feat: 取消前端計算 cumulative sum，payoff 的計算改由後端完成。前端只要負責顯示 payoff 即可。