### PR TITLE
Feature/fix refresh page error

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,5 @@
 import { Routes, Route } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
-import { useDispatch } from 'react-redux'
-
-import { API_ROOT } from './api.config'
-import { GameStages } from './models/GameStages'
-import { updateNetworksAvailable, updateToolsAvailable, updateGameStage } from './pages/game/game.slice'
-
+import { DataContextProvider } from './DataContext'
 import { Home } from './pages/Home'
 import { TourIntroduction } from './pages/tour/TourIntroduction'
 import { TourTools } from './pages/tour/TourTools'
@@ -14,63 +8,18 @@ import { NetworkIntroduction } from './pages/game/NetworkIntroduction'
 import { GamePage } from './pages/game/Game'
 import { Questionnaire } from './pages/questionnaire/Questionnaire'
 
-const App = () => {
-  const dispatch = useDispatch()
-
-  const { isLoading: isNetworksLoading, isError: isNetworksApiError } = useQuery({
-    queryKey: ['networkAvailable'],
-    queryFn: async () => {
-      const response = await fetch(`${API_ROOT}/networks/`, {
-        method: 'GET',
-      })
-      if (!response.ok) {
-        throw new Error('Failed to fetch available networks')
-      }
-      dispatch(updateGameStage(GameStages.GRAPH))
-
-      return response.json()
-    },
-    onSuccess: networksAvailableResponse => {
-      dispatch(updateNetworksAvailable(networksAvailableResponse))
-    },
-  })
-
-  const { isLoading: isToolsLoading, isError: isToolsApiError } = useQuery({
-    queryKey: ['toolsAvailable'],
-    queryFn: async () => {
-      const response = await fetch(`${API_ROOT}/tools/`, {
-        method: 'GET',
-      })
-      if (!response.ok) {
-        throw new Error('Failed to fetch available tools')
-      }
-      return response.json()
-    },
-    onSuccess: toolsAvailableResponse => {
-      dispatch(updateToolsAvailable(toolsAvailableResponse))
-    },
-  })
-
-  return (
+const App = () => (
+  <DataContextProvider>
     <Routes>
       <Route path="/" element={<Home />} />
       <Route path="/tour/introduction" element={<TourIntroduction />} />
       <Route path="/tour/tools" element={<TourTools />} />
       <Route path="/tour/actions" element={<TourActions />} />
-      <Route
-        path="/network-selection"
-        element={
-          <NetworkIntroduction
-            isNetworksApiError={isNetworksApiError}
-            isToolsApiError={isToolsApiError}
-            loading={isNetworksLoading || isToolsLoading}
-          />
-        }
-      />
+      <Route path="/network-selection" element={<NetworkIntroduction />} />
       <Route path="/game" element={<GamePage />} />
       <Route path="/questionnaire" element={<Questionnaire />} />
     </Routes>
-  )
-}
+  </DataContextProvider>
+)
 
 export default App

--- a/src/DataContext.jsx
+++ b/src/DataContext.jsx
@@ -1,0 +1,67 @@
+import { createContext, useContext, useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import PropTypes from 'prop-types'
+import { API_ROOT } from './api.config'
+
+const DataContext = createContext()
+
+export const useContextData = () => useContext(DataContext)
+
+export const DataContextProvider = ({ children }) => {
+  const gameId = localStorage.getItem('gameId')
+
+  const {
+    data: networksAvailable,
+    isLoading: isNetworksApiLoading,
+    isError: isNetworksApiError,
+    refetch: refetchNetworksAvailable,
+  } = useQuery({
+    queryKey: ['networkAvailable', gameId],
+    queryFn: async () => {
+      const response = await fetch(`${API_ROOT}/networks/`, {
+        method: 'GET',
+      })
+      if (!response.ok) {
+        throw new Error('Failed to fetch available networks')
+      }
+
+      return response.json() ?? {}
+    },
+  })
+
+  const {
+    data: toolsAvailable,
+    isLoading: isToolsApiLoading,
+    isError: isToolsApiError,
+    refetch: refetchToolsAvailable,
+  } = useQuery({
+    queryKey: ['toolsAvailable', gameId],
+    queryFn: async () => {
+      const response = await fetch(`${API_ROOT}/tools/`, {
+        method: 'GET',
+      })
+      if (!response.ok) {
+        throw new Error('Failed to fetch available tools')
+      }
+      return response.json() ?? {}
+    },
+  })
+
+  const contextValue = useMemo(
+    () => ({
+      data: { networksAvailable, toolsAvailable },
+      loadingStates: { isNetworksApiLoading, isToolsApiLoading },
+      errorStates: { isNetworksApiError, isToolsApiError },
+      refetch: () => {
+        refetchNetworksAvailable()
+        refetchToolsAvailable()
+      },
+    }),
+    [networksAvailable, toolsAvailable, isNetworksApiLoading, isToolsApiLoading, isNetworksApiError, isToolsApiError],
+  )
+
+  return <DataContext.Provider value={contextValue}>{children}</DataContext.Provider>
+}
+DataContextProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+}

--- a/src/pages/game/Game.jsx
+++ b/src/pages/game/Game.jsx
@@ -9,7 +9,6 @@ import { API_ROOT, postHeaders } from '../../api.config'
 import { getViewport } from '../../utils'
 import { Button } from '../../components'
 import {
-  selectNetworkCode,
   selectSelectedTool,
   selectRound,
   selectRealGraphData,
@@ -30,7 +29,7 @@ import { GameEndDialog } from './GameEndDialog'
 export const GamePage = () => {
   const dispatch = useDispatch()
   const navigate = useNavigate()
-  const networkCode = useSelector(selectNetworkCode)
+  const networkCode = localStorage.getItem('thisRoundNetworkCode')
   const { width } = getViewport()
   const selectedTool = useSelector(selectSelectedTool)
   const round = useSelector(selectRound)

--- a/src/pages/game/NetworkIntroduction.jsx
+++ b/src/pages/game/NetworkIntroduction.jsx
@@ -1,23 +1,29 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useSelector, useDispatch } from 'react-redux'
-import PropTypes from 'prop-types'
+import { useDispatch } from 'react-redux'
 import styled from '@emotion/styled'
 import { Accordion, AccordionSummary, AccordionDetails } from '@mui/material'
 
+import { useContextData } from '../../DataContext'
 import { color } from '../../styles'
 import { Button, Progress } from '../../components'
-import { selectNetworksAvailable, updateNetworkCode } from './game.slice'
+import { updateNetworkCode } from './game.slice'
 import { getRandomNumber } from './game.utils'
 
-export const NetworkIntroduction = ({ isNetworksApiError, isToolsApiError, loading }) => {
+export const NetworkIntroduction = () => {
   const navigate = useNavigate()
   const dispatch = useDispatch()
-  const networksAvailable = useSelector(selectNetworksAvailable)
   const [expandedNetworkKey, setExpandedNetworkKey] = useState(null)
   const excludeNetworkCodeNumbers = JSON.parse(sessionStorage.getItem('excludeNetworkCodeNumbers')) || []
 
-  if (loading) {
+  const contextData = useContextData()
+  const {
+    data: { networksAvailable = {} },
+    loadingStates: { isNetworksApiLoading, isToolsApiLoading },
+    errorStates: { isNetworksApiError, isToolsApiError },
+  } = contextData
+
+  if (isNetworksApiLoading || isToolsApiLoading) {
     return (
       <StyledLoadingContainer>
         <Progress />
@@ -76,11 +82,6 @@ export const NetworkIntroduction = ({ isNetworksApiError, isToolsApiError, loadi
       </StyledButtonContainer>
     </StyledContainer>
   )
-}
-NetworkIntroduction.propTypes = {
-  isNetworksApiError: PropTypes.bool.isRequired,
-  isToolsApiError: PropTypes.bool.isRequired,
-  loading: PropTypes.bool.isRequired,
 }
 
 const StyledLoadingContainer = styled.div`

--- a/src/pages/game/NetworkIntroduction.jsx
+++ b/src/pages/game/NetworkIntroduction.jsx
@@ -1,18 +1,15 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useDispatch } from 'react-redux'
 import styled from '@emotion/styled'
 import { Accordion, AccordionSummary, AccordionDetails } from '@mui/material'
 
 import { useContextData } from '../../DataContext'
 import { color } from '../../styles'
 import { Button, Progress } from '../../components'
-import { updateNetworkCode } from './game.slice'
 import { getRandomNumber } from './game.utils'
 
 export const NetworkIntroduction = () => {
   const navigate = useNavigate()
-  const dispatch = useDispatch()
   const [expandedNetworkKey, setExpandedNetworkKey] = useState(null)
   const excludeNetworkCodeNumbers = JSON.parse(sessionStorage.getItem('excludeNetworkCodeNumbers')) || []
 
@@ -69,7 +66,8 @@ export const NetworkIntroduction = () => {
               totalCount: Object.keys(networksAvailable).length,
               excludeNumbers: excludeNetworkCodeNumbers,
             })
-            dispatch(updateNetworkCode(randomNetworkCodeNumber.toString()))
+            const thisRoundNetworkCode = randomNetworkCodeNumber.toString()
+            localStorage.setItem('thisRoundNetworkCode', thisRoundNetworkCode)
             sessionStorage.setItem(
               'excludeNetworkCodeNumbers',
               JSON.stringify([...excludeNetworkCodeNumbers, randomNetworkCodeNumber]),

--- a/src/pages/game/ToolSelectionDialog.jsx
+++ b/src/pages/game/ToolSelectionDialog.jsx
@@ -5,16 +5,21 @@ import PropTypes from 'prop-types'
 import styled from '@emotion/styled'
 import { Accordion, AccordionSummary, AccordionDetails } from '@mui/material'
 
+import { useContextData } from '../../DataContext'
 import { getViewport } from '../../utils'
 import { color } from '../../styles'
 import { Dialog, DialogTypes, Chip, Progress } from '../../components'
-import { selectToolsAvailable, selectPayoff } from './game.slice'
+import { selectPayoff } from './game.slice'
 import { PayoffChart } from './PayoffChart'
 
 export const ToolSelectionDialog = ({ open = false, loading, onConfirm = () => {} }) => {
-  const toolsAvailable = useSelector(selectToolsAvailable)
   const payoff = useSelector(selectPayoff)
   const { width } = getViewport()
+
+  const contextData = useContextData()
+  const {
+    data: { toolsAvailable = {} },
+  } = contextData
 
   const [expandedTool, setExpandedTool] = useState(null)
 

--- a/src/pages/game/game.slice.js
+++ b/src/pages/game/game.slice.js
@@ -3,10 +3,6 @@ import { createSlice } from '@reduxjs/toolkit'
 import { GameStages } from '../../models/GameStages'
 
 const initialState = {
-  networksAvailable: {},
-  toolsAvailable: {},
-
-  gameStage: GameStages.NETWORK_SELECTION,
   networkCode: null,
   realGraphData: null,
   graphRanking: null,
@@ -18,18 +14,6 @@ const gameSlice = createSlice({
   name: 'gameSlice',
   initialState,
   reducers: {
-    updateNetworksAvailable: (state, action) => {
-      state.networksAvailable = action.payload
-    },
-
-    updateToolsAvailable: (state, action) => {
-      state.toolsAvailable = action.payload
-    },
-
-    updateGameStage: (state, action) => {
-      state.gameStage = action.payload
-    },
-
     updateNetworkCode: (state, action) => {
       state.networkCode = action.payload
     },
@@ -65,10 +49,6 @@ const gameSlice = createSlice({
 })
 
 export const {
-  updateNetworksAvailable,
-  updateToolsAvailable,
-
-  updateGameStage,
   updateNetworkCode,
   updateRealGraphData,
   updateGraphRanking,
@@ -78,10 +58,6 @@ export const {
 } = gameSlice.actions
 export default gameSlice.reducer
 
-export const selectNetworksAvailable = state => state.gameReducer.networksAvailable
-export const selectToolsAvailable = state => state.gameReducer.toolsAvailable
-
-export const selectGameStage = state => state.gameReducer.gameStage
 export const selectNetworkCode = state => state.gameReducer.networkCode
 export const selectRealGraphData = state => state.gameReducer.realGraphData
 export const selectGraphRanking = state => state.gameReducer.graphRanking

--- a/src/pages/game/game.slice.js
+++ b/src/pages/game/game.slice.js
@@ -3,7 +3,6 @@ import { createSlice } from '@reduxjs/toolkit'
 import { GameStages } from '../../models/GameStages'
 
 const initialState = {
-  networkCode: null,
   realGraphData: null,
   graphRanking: null,
   selectedTool: [],
@@ -14,10 +13,6 @@ const gameSlice = createSlice({
   name: 'gameSlice',
   initialState,
   reducers: {
-    updateNetworkCode: (state, action) => {
-      state.networkCode = action.payload
-    },
-
     updateRealGraphData: (state, action) => {
       state.realGraphData = action.payload
     },
@@ -48,17 +43,10 @@ const gameSlice = createSlice({
   },
 })
 
-export const {
-  updateNetworkCode,
-  updateRealGraphData,
-  updateGraphRanking,
-  updateSelectedTool,
-  updatePayoff,
-  resetGameData,
-} = gameSlice.actions
+export const { updateRealGraphData, updateGraphRanking, updateSelectedTool, updatePayoff, resetGameData } =
+  gameSlice.actions
 export default gameSlice.reducer
 
-export const selectNetworkCode = state => state.gameReducer.networkCode
 export const selectRealGraphData = state => state.gameReducer.realGraphData
 export const selectGraphRanking = state => state.gameReducer.graphRanking
 export const selectSelectedTool = state => state.gameReducer.selectedTool

--- a/src/pages/game/information-blocks/NetworkInformationBlock.jsx
+++ b/src/pages/game/information-blocks/NetworkInformationBlock.jsx
@@ -1,17 +1,22 @@
 import { useSelector } from 'react-redux'
 import styled from '@emotion/styled'
-import { selectNetworkCode, selectNetworksAvailable } from '../game.slice'
+import { useContextData } from '../../../DataContext'
+import { selectNetworkCode } from '../game.slice'
 import { Chip } from '../../../components'
 import { StyledCard, StyledRow } from './styles'
 
 export const NetworkInformationBlock = () => {
-  const selectedNetworkCode = useSelector(selectNetworkCode)
-  const networksAvailable = useSelector(selectNetworksAvailable)
+  const selectedNetworkCode = useSelector(selectNetworkCode) ?? 0
+
+  const contextData = useContextData()
+  const {
+    data: { networksAvailable = {} },
+  } = contextData
 
   const [selectedNetworkObject] = Object.values(networksAvailable).filter(
     network => network.code === selectedNetworkCode,
   )
-  const { displayName = '', introduction = '' } = selectedNetworkObject
+  const { displayName = '', introduction = '' } = selectedNetworkObject ?? {}
 
   return (
     <StyledCard visible="true">

--- a/src/pages/game/information-blocks/NetworkInformationBlock.jsx
+++ b/src/pages/game/information-blocks/NetworkInformationBlock.jsx
@@ -1,12 +1,10 @@
-import { useSelector } from 'react-redux'
 import styled from '@emotion/styled'
 import { useContextData } from '../../../DataContext'
-import { selectNetworkCode } from '../game.slice'
 import { Chip } from '../../../components'
 import { StyledCard, StyledRow } from './styles'
 
 export const NetworkInformationBlock = () => {
-  const selectedNetworkCode = useSelector(selectNetworkCode) ?? 0
+  const selectedNetworkCode = localStorage.getItem('thisRoundNetworkCode')
 
   const contextData = useContextData()
   const {

--- a/src/pages/tour/TourActions.jsx
+++ b/src/pages/tour/TourActions.jsx
@@ -1,12 +1,11 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { useSelector } from 'react-redux'
 import styled from '@emotion/styled'
 
 import { API_ROOT } from '../../api.config'
+import { useContextData } from '../../DataContext'
 import { getViewport } from '../../utils'
-import { selectToolsAvailable } from '../game/game.slice'
 import { Button } from '../../components'
 import { ForceGraph } from '../game/ForceGraph'
 import { TourLayout } from './TourLayout'
@@ -15,7 +14,10 @@ export const TourActions = () => {
   const { width: viewportWidth, height: viewportHeight } = getViewport()
   const graphWidth = viewportWidth > 768 ? viewportWidth / 2 : viewportWidth - 28
   const graphHeight = viewportWidth > 768 ? viewportHeight - 200 : viewportHeight / 2
-  const toolsAvailable = useSelector(selectToolsAvailable)
+  const contextData = useContextData()
+  const {
+    data: { toolsAvailable = {} },
+  } = contextData
   const demoTool = toolsAvailable.HDA
 
   const [removedNodeIds, setRemovedNodeIds] = useState([])

--- a/src/pages/tour/TourTools.jsx
+++ b/src/pages/tour/TourTools.jsx
@@ -1,16 +1,17 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import { useSelector, useDispatch } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import PropTypes from 'prop-types'
 import styled from '@emotion/styled'
 import { Accordion, AccordionDetails, AccordionSummary } from '@mui/material'
 
 import { API_ROOT, postHeaders } from '../../api.config'
+import { useContextData } from '../../DataContext'
 import { getViewport } from '../../utils'
 import { Button, Checkbox, CheckboxLevels } from '../../components'
 import { color } from '../../styles'
-import { selectToolsAvailable, updateGraphRanking } from '../game/game.slice'
+import { updateGraphRanking } from '../game/game.slice'
 import { getToolImage } from './tour.utils'
 
 import { TourLayout } from './TourLayout'
@@ -58,8 +59,11 @@ export const TourTools = () => {
   const { width: viewportWidth, height: viewportHeight } = getViewport()
   const graphWidth = viewportWidth > 768 ? viewportWidth / 2 : viewportWidth - 28
   const graphHeight = viewportWidth > 768 ? viewportHeight - 200 : viewportHeight / 2
+  const contextData = useContextData()
+  const {
+    data: { toolsAvailable = {} },
+  } = contextData
 
-  const toolsAvailable = useSelector(selectToolsAvailable)
   const [expandedTool, setExpandedTool] = useState(toolsAvailable.HDA)
   const [checkedTools, setCheckedTools] = useState([])
   const toolsAvailableWithoutNoHelp = Object.entries(toolsAvailable)


### PR DESCRIPTION
# Issue Link

https://github.com/johnny890122/FINDER_react_frontend/issues/65

## Fix

- 在正式遊戲畫面，當 refresh 頁面後，網頁會 crash 掉。我猜原因有很多，以後端看到的來說，應該是前端重打了一些 api，但是並未放入正確的 argument，導致無法成功 fetch 新資料。
- 操作頁面若不小心跳到上一頁再跳回來的話網頁會當機，無法繼續操作（重整也無法），需結束遊戲再重新開始