### PR TITLE
Feature/lock node actions when fetching payoff

### DIFF
--- a/src/pages/game/ForceGraph.jsx
+++ b/src/pages/game/ForceGraph.jsx
@@ -15,6 +15,7 @@ import { selectGraphRanking, updateRealGraphData } from './game.slice'
 export const ForceGraph = ({
   withAction = true,
   loading,
+  isNodeRankingOrPayoffLoading,
   graphData,
   selectedTool,
   disabledNodeIds,
@@ -62,7 +63,7 @@ export const ForceGraph = ({
 
   const handleNodeClick = node => {
     if (disabledNodeIds.includes(node.id)) return
-    if (!withAction) return
+    if (!withAction || isNodeRankingOrPayoffLoading) return
     setIsPayoffLoading(true)
     setRemovedNodeIds([...removedNodeIds, node.id])
     setHoveredNode(null)
@@ -99,6 +100,7 @@ export const ForceGraph = ({
 
   return (
     <StyledForceGraphContainer width={graphWidth} height={graphHeight}>
+      {isNodeRankingOrPayoffLoading && <StyledTipContainer>請選擇輔助工具或稍等排名計算中...</StyledTipContainer>}
       <ForceGraph2D
         ref={graphRef}
         graphData={graphData}
@@ -115,7 +117,7 @@ export const ForceGraph = ({
           return color.primaryColor300
         }}
         nodeLabel={node => {
-          if (!graphRanking || !Object.keys(graphRanking).length) return `#${node.id}`
+          if (!graphRanking || !Object.keys(graphRanking).length || !selectedTool.displayName) return `#${node.id}`
           return `#${node.id}，${selectedTool.displayName}排名第 ${graphRanking[node.id]}`
         }}
         width={graphWidth}
@@ -152,6 +154,7 @@ export const ForceGraph = ({
 ForceGraph.propTypes = {
   withAction: PropTypes.bool,
   loading: PropTypes.bool,
+  isNodeRankingOrPayoffLoading: PropTypes.bool,
   graphData: PropTypes.oneOfType([PropTypes.object, PropTypes.oneOf([null, undefined])]),
   selectedTool: PropTypes.object,
   disabledNodeIds: PropTypes.array,
@@ -166,6 +169,7 @@ ForceGraph.propTypes = {
 ForceGraph.defaultProps = {
   withAction: true,
   loading: false,
+  isNodeRankingOrPayoffLoading: false,
   graphData: null,
   selectedTool: {},
   disabledNodeIds: [],
@@ -220,4 +224,12 @@ const StyledButtonGroup = styled(ButtonGroup)`
     border-top-left-radius: 0 !important;
     border-bottom-left-radius: 0 !important;
   }
+`
+const StyledTipContainer = styled.div`
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
+  border: 1px solid ${color.primaryColor100};
+  border-radius: 0.25rem;
+  padding: 0.25rem;
 `

--- a/src/pages/game/ForceGraph.jsx
+++ b/src/pages/game/ForceGraph.jsx
@@ -21,6 +21,7 @@ export const ForceGraph = ({
   removedNodeIds,
   setRemovedNodeIds,
   setIsReadyGetPayoff,
+  setIsPayoffLoading,
   onNodeRemoved,
   width,
   height,
@@ -61,6 +62,8 @@ export const ForceGraph = ({
 
   const handleNodeClick = node => {
     if (disabledNodeIds.includes(node.id)) return
+    if (!withAction) return
+    setIsPayoffLoading(true)
     setRemovedNodeIds([...removedNodeIds, node.id])
     setHoveredNode(null)
     setIsReadyGetPayoff(true)
@@ -90,28 +93,6 @@ export const ForceGraph = ({
     return (
       <StyledForceGraphContainer width={graphWidth} height={graphHeight}>
         <Progress />
-      </StyledForceGraphContainer>
-    )
-  }
-
-  if (!withAction) {
-    return (
-      <StyledForceGraphContainer width={graphWidth} height={graphHeight}>
-        <ForceGraph2D
-          graphData={graphData}
-          nodeVal={node => {
-            if (!graphRanking) return 1
-            return getNodeValue({ nodeCount: Object.values(graphRanking).length, ranking: graphRanking[node.id] })
-          }}
-          nodeColor={() => color.primaryColor300}
-          nodeLabel={node => {
-            if (!graphRanking || !Object.keys(graphRanking).length) return `#${node.id}`
-            return `#${node.id}，${selectedTool.displayName}排名第 ${graphRanking[node.id]}`
-          }}
-          width={graphWidth}
-          height={graphHeight}
-          minZoom={1}
-        />
       </StyledForceGraphContainer>
     )
   }
@@ -177,6 +158,7 @@ ForceGraph.propTypes = {
   removedNodeIds: PropTypes.array,
   setRemovedNodeIds: PropTypes.func,
   setIsReadyGetPayoff: PropTypes.func,
+  setIsPayoffLoading: PropTypes.func,
   onNodeRemoved: PropTypes.func,
   width: PropTypes.number,
   height: PropTypes.number,
@@ -190,6 +172,7 @@ ForceGraph.defaultProps = {
   removedNodeIds: [],
   setRemovedNodeIds: () => {},
   setIsReadyGetPayoff: () => {},
+  setIsPayoffLoading: () => {},
   onNodeRemoved: () => {},
   width: 0,
   height: 0,

--- a/src/pages/game/Game.jsx
+++ b/src/pages/game/Game.jsx
@@ -36,6 +36,7 @@ export const GamePage = () => {
   const [isQuitGameDialogOpen, setIsQuitGameDialogOpen] = useState(false)
   const [isReadyGetNodeRanking, setIsReadyGetNodeRanking] = useState(false)
   const [isReadyGetPayoff, setIsReadyGetPayoff] = useState(false)
+  const [isPayoffLoading, setIsPayoffLoading] = useState(false)
   const [removedNodeIds, setRemovedNodeIds] = useState([])
 
   useEffect(() => {
@@ -134,6 +135,7 @@ export const GamePage = () => {
     },
     onSettled: () => {
       setIsReadyGetPayoff(false)
+      setIsPayoffLoading(false)
       dispatch(
         updateRealGraphData(
           removeNodeAndRelatedLinksFromGraphData({
@@ -179,13 +181,14 @@ export const GamePage = () => {
           />
         </StyledInformationBlocksContainer>
         <ForceGraph
-          withAction={!isNodeRankingLoading}
+          withAction={!isNodeRankingLoading && !isPayoffLoading}
           loading={!isGameEndDialogOpen && isGraphDataLoading}
           graphData={graphData}
           selectedTool={selectedTool[selectedTool.length - 1]}
           removedNodeIds={removedNodeIds}
           setRemovedNodeIds={setRemovedNodeIds}
           setIsReadyGetPayoff={setIsReadyGetPayoff}
+          setIsPayoffLoading={setIsPayoffLoading}
         />
       </StyledGameContainer>
     </StyledGamePageContainer>

--- a/src/pages/game/Game.jsx
+++ b/src/pages/game/Game.jsx
@@ -181,8 +181,8 @@ export const GamePage = () => {
           />
         </StyledInformationBlocksContainer>
         <ForceGraph
-          withAction={!isNodeRankingLoading && !isPayoffLoading}
           loading={!isGameEndDialogOpen && isGraphDataLoading}
+          isNodeRankingOrPayoffLoading={!selectedTool.length || isNodeRankingLoading || isPayoffLoading}
           graphData={graphData}
           selectedTool={selectedTool[selectedTool.length - 1]}
           removedNodeIds={removedNodeIds}

--- a/src/pages/tour/TourActions.jsx
+++ b/src/pages/tour/TourActions.jsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled'
 
 import { API_ROOT, postHeaders } from '../../api.config'
 import { useContextData } from '../../DataContext'
-import { selectRealGraphData, updateGraphRanking, updateRealGraphData } from '../game/game.slice'
+import { selectRealGraphData, updateGraphRanking, updateRealGraphData, resetGameData } from '../game/game.slice'
 import { getViewport } from '../../utils'
 import { removeNodeAndRelatedLinksFromGraphData } from '../game/game.utils'
 import { filterDisabledNodeIds } from './tour.utils'
@@ -97,6 +97,7 @@ export const TourActions = () => {
   }
 
   const onConfirmToPlayGame = () => {
+    dispatch(resetGameData())
     navigate('/network-selection')
   }
 


### PR DESCRIPTION
# Issue Link

- https://github.com/johnny890122/FINDER_react_frontend/issues/93
- https://github.com/johnny890122/FINDER_react_frontend/issues/92

## Feature

- 在某個指標下，選擇 node 等待 payoff 回傳的時候，應該要鎖定畫面中的 graph
- 在前端選擇指標，到後端回傳排名資料的這段期間，可以加個 Loading 的圖示，提示實驗者